### PR TITLE
Rise max length for slugs

### DIFF
--- a/src/Genj/FaqBundle/Entity/Question.php
+++ b/src/Genj/FaqBundle/Entity/Question.php
@@ -59,7 +59,7 @@ class Question
 
     /**
      * @Gedmo\Slug(fields={"headline"}, updatable=false)
-     * @ORM\Column(type="string", length=255, nullable=false)
+     * @ORM\Column(type="string", length=100, nullable=false)
      */
     protected $slug;
 

--- a/src/Genj/FaqBundle/Entity/Question.php
+++ b/src/Genj/FaqBundle/Entity/Question.php
@@ -59,7 +59,7 @@ class Question
 
     /**
      * @Gedmo\Slug(fields={"headline"}, updatable=false)
-     * @ORM\Column(type="string", length=50, nullable=false)
+     * @ORM\Column(type="string", length=255, nullable=false)
      */
     protected $slug;
 


### PR DESCRIPTION
I am having issues with slugs too small when it is difficult no conflict or resume diferent the name. So I think that it is a good idea raise to the maximu storable as varchar variable. If not agree with this change, at least that it could be configurable in config settings of the bundle